### PR TITLE
Remove windowed mode edits

### DIFF
--- a/NFSPSExtraOptions/dllmain.cpp
+++ b/NFSPSExtraOptions/dllmain.cpp
@@ -13,7 +13,6 @@ bool bWindowedMode, CenterWindow, SkipMovies, SkipNISs, IsPlayerNameSet, ExOptsT
 int ThreadDelay, StartingCash, hotkeyUnlockAllThings, hotkeyAutoDrive, hotkeyPhysSwitch, hotkeyFreezeCamera, hotkeyToggleHeadlights, MaximumLaps, MaximumRepairMarkers;
 char* IntroMovieName, *PlayerName;
 DWORD GameState;
-HWND windowHandle;
 
 char* CopyrightString = "© 2007 Electronic Arts Inc. All rights reserved.^NFSPS Extra Options - © 2019 ExOpts Team. No rights reserved.";
 DWORD _A7EBC389_New = (DWORD)CopyrightString;
@@ -379,27 +378,7 @@ DWORD WINAPI Thing(LPVOID)
 		Sleep(ThreadDelay);
 
 		GameState = *(DWORD*)0xABB510; // 3 = FE, 4&5 = Loading screen, 6 = Gameplay
-		windowHandle = *(HWND*)0xAC6ED8;
-		bWindowedMode = *(bool*)0xAC6EFC;
 		IsOnFocus = !(*(bool*)0xAC1055);
-
-		// Center game window (frameless only)
-		if (bWindowedMode && CenterWindow && windowHandle && !once3)
-		{
-			HWND hwndScreen;
-			RECT rectScreen, rectGame;
-
-			hwndScreen = GetDesktopWindow();
-			GetWindowRect(hwndScreen, &rectScreen); // Get screen res
-			GetClientRect(windowHandle, &rectGame); // Get game res
-
-			int XPos = ((rectScreen.right - rectScreen.left) / 2 - (rectGame.right - rectGame.left) / 2);
-			int YPos = ((rectScreen.bottom - rectScreen.top) / 2 - (rectGame.bottom - rectGame.top) / 2);
-
-			SetWindowPos(windowHandle, NULL, XPos, YPos, (rectGame.right - rectGame.left), (rectGame.bottom - rectGame.top), SWP_NOZORDER);
-
-			once3 = 1;
-		}
 
 		if ((GetAsyncKeyState(hotkeyUnlockAllThings) & 1) && IsOnFocus) // Unlock All Things
 		{


### PR DESCRIPTION
The [generic fix from ThirteenAG]( https://github.com/ThirteenAG/WidescreenFixesPack/blob/adae7877643743746e7bffc005b97e77dafa48d0/source/NFSProStreet.GenericFix/dllmain.cpp#L423) also handles windowed mode. 

Using NFSPSExOpts together with the generic fix makes the game window invisible. The solution is to either 1. make windowed mode edits an ini option or 2. remove them altogether. I went with 2. but if you prefer 1. you should implement it.